### PR TITLE
Feature/#14 소셜로그인 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import Header from './components/Header';
 import ResultTab from './components/resultTab/ResultTab';
 import Home from './pages/Home';
 import ResultDetail from './pages/ResultDetail';
+import AuthCallback from './components/AuthCallback';
 
 function App() {
   return (
@@ -14,6 +15,7 @@ function App() {
           <Route path="/frontend" element={<Home />} />
           <Route path="/frontend/results" element={<ResultTab />} />
           <Route path="/frontend/rescue/:noticeId" element={<ResultDetail />} />
+          <Route path="/frontend/auth" element={<AuthCallback />} />
         </Routes>
       </BrowserRouter>
     </div>

--- a/src/components/AuthCallback.js
+++ b/src/components/AuthCallback.js
@@ -1,24 +1,27 @@
+/* eslint-disable no-unused-vars */
 import axios from 'axios';
 import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 function AuthCallback() {
   const navigate = useNavigate();
-  // const [loginStatus, setloginStatus] = useState(false);
   const code = new URL(window.location.href).searchParams.get('code');
   const getToken = async () => {
     try {
-      const response = await axios.get('', code);
-      window.localStorage.setItem('token', response.data);
+      const response = await axios.get(
+        `https://mungtage.shop/api/v1/oauth?code=${code}`,
+      );
+      window.localStorage.setItem('token', response.data.jwtToken);
       alert('환영합니다!');
     } catch (error) {
       alert(`로그인에 실패했습니다. 다시 시도해주세요: ${error}`);
+    } finally {
+      navigate('/frontend', { replace: true });
     }
   };
   useEffect(() => {
     getToken();
   }, []);
-  navigate('/', { replace: true });
   return <div>waiting...</div>;
 }
 

--- a/src/components/AuthCallback.js
+++ b/src/components/AuthCallback.js
@@ -1,0 +1,9 @@
+import React from 'react';
+
+function AuthCallback() {
+  const code = new URL(window.location.href).searchParams.get('code');
+  console.log(code);
+  return <div>waiting..</div>;
+}
+
+export default AuthCallback;

--- a/src/components/AuthCallback.js
+++ b/src/components/AuthCallback.js
@@ -1,9 +1,25 @@
-import React from 'react';
+import axios from 'axios';
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 
 function AuthCallback() {
+  const navigate = useNavigate();
+  // const [loginStatus, setloginStatus] = useState(false);
   const code = new URL(window.location.href).searchParams.get('code');
-  console.log(code);
-  return <div>waiting..</div>;
+  const getToken = async () => {
+    try {
+      const response = await axios.get('', code);
+      window.localStorage.setItem('token', response.data);
+      alert('환영합니다!');
+    } catch (error) {
+      alert(`로그인에 실패했습니다. 다시 시도해주세요: ${error}`);
+    }
+  };
+  useEffect(() => {
+    getToken();
+  }, []);
+  navigate('/', { replace: true });
+  return <div>waiting...</div>;
 }
 
 export default AuthCallback;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -3,6 +3,10 @@ import { Link } from 'react-router-dom';
 import LOGO from '../assets/Logo.svg';
 
 function Header() {
+  const accessToken = window.localStorage.getItem('token');
+  const logoutHandler = () => {
+    window.localStorage.removeItem('token');
+  };
   return (
     <header>
       <div className="bg-white h-[15vh] flex justify-between sticky px-10 top-0 z-50">
@@ -23,9 +27,15 @@ function Header() {
           </div>
 
           <div className="flex px-2 font-bold items-center font-mono text-[#000000] hover:font-black text-xl">
-            <a href="https://mungtage.shop/oauth2/authorization/google">
-              로그인
-            </a>
+            {accessToken ? (
+              <a href="https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?response_type=code&client_id=456564400960-m9gm7l9iac36lbnqcvpvkn29s2nluklm.apps.googleusercontent.com&scope=profile%20email&state=7rDIGTpshm6-oFYGiwzrbeVEJyj488QwXKRLTrAB-78%3D&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Ffrontend%2Fauth&flowName=GeneralOAuthFlow">
+                로그인
+              </a>
+            ) : (
+              <button type="button" onClick={logoutHandler}>
+                로그아웃
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,11 +1,18 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+/* eslint-disable no-unused-vars */
+import React, { useEffect, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
 import LOGO from '../assets/Logo.svg';
 
 function Header() {
-  const accessToken = window.localStorage.getItem('token');
+  const [accessToken, setAccessToken] = useState(
+    window.localStorage.getItem('token'),
+  );
+  useEffect(() => {
+    setAccessToken(window.localStorage.getItem('token'));
+  });
   const logoutHandler = () => {
     window.localStorage.removeItem('token');
+    setAccessToken(null);
   };
   return (
     <header>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -23,7 +23,9 @@ function Header() {
           </div>
 
           <div className="flex px-2 font-bold items-center font-mono text-[#000000] hover:font-black text-xl">
-            로그인
+            <a href="https://mungtage.shop/oauth2/authorization/google">
+              로그인
+            </a>
           </div>
         </div>
       </div>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -27,7 +27,7 @@ function Header() {
           </div>
 
           <div className="flex px-2 font-bold items-center font-mono text-[#000000] hover:font-black text-xl">
-            {accessToken ? (
+            {!accessToken ? (
               <a href="https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?response_type=code&client_id=456564400960-m9gm7l9iac36lbnqcvpvkn29s2nluklm.apps.googleusercontent.com&scope=profile%20email&state=7rDIGTpshm6-oFYGiwzrbeVEJyj488QwXKRLTrAB-78%3D&redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Ffrontend%2Fauth&flowName=GeneralOAuthFlow">
                 로그인
               </a>


### PR DESCRIPTION
- 백엔드 api 연동 완료
- 인가코드 백엔드에 보내서 토큰 받으면 localStorage에 저장
- 토큰 받았으면 로그인 성공 alert, 실패했으면 실패 alert 띄운 후 홈페이지로 이동
- localStorage 확인해서 토큰 있으면 로그인/로그아웃 버튼 전환


- 맨 처음 로그인 후 로그아웃으로 버튼 바뀌지 않는 문제(한 번 더 누르면 바뀝니다. fix 예정)