### PR TITLE
Feature/#30 분실 등록 결과 확인 및 삭제 폼 제작

### DIFF
--- a/src/components/lostPostTab/IsImageUpload.js
+++ b/src/components/lostPostTab/IsImageUpload.js
@@ -1,0 +1,27 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+
+function IsImageUpload({ imageURL }) {
+  return (
+    <section className="dropzone flex justify-center h-full w-full">
+      <div className="flex justify-center h-full w-full items-center">
+        <div>
+          <div>
+            <img
+              src={imageURL}
+              alt="This is what you uploaded."
+              className="flex flex-col justify-center items-center w-full h-[50vh]"
+            />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default IsImageUpload;
+
+// IsImageUpload.propTypes = {
+//   onImageURL: PropTypes.func.isRequired,
+// };

--- a/src/components/lostPostTab/IsImageUpload.js
+++ b/src/components/lostPostTab/IsImageUpload.js
@@ -4,14 +4,14 @@ import React from 'react';
 
 function IsImageUpload({ imageURL }) {
   return (
-    <section className="dropzone flex justify-center h-full w-full">
+    <section className="flex justify-center h-full w-full">
       <div className="flex justify-center h-full w-full items-center">
-        <div>
-          <div>
+        <div className="flex justify-center h-full w-full items-center">
+          <div className="flex justify-center h-full w-[150%] items-center ">
             <img
               src={imageURL}
               alt="This is what you uploaded."
-              className="flex flex-col justify-center items-center w-full h-[50vh]"
+              className="flex flex-col justify-center items-center w-full rounded-md"
             />
           </div>
         </div>

--- a/src/components/lostPostTab/IsLostForm.js
+++ b/src/components/lostPostTab/IsLostForm.js
@@ -70,6 +70,7 @@ function IsLostForm({ formData = [] }) {
                 type="gender"
                 value={formData.sexCode || ''}
                 className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20  bg-gray-100 text-gray-400 placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                disabled
               />
             </div>
           </div>
@@ -83,6 +84,7 @@ function IsLostForm({ formData = [] }) {
                 type="neuter"
                 value={formData.neuterYN || ''}
                 className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-gray-100 text-gray-400 placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                disabled
               />
             </div>
           </div>

--- a/src/components/lostPostTab/IsLostForm.js
+++ b/src/components/lostPostTab/IsLostForm.js
@@ -1,0 +1,107 @@
+/* eslint-disable react/prop-types */
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React from 'react';
+import axios from 'axios';
+
+function IsLostForm({ formData = [] }) {
+  const onDelete = async (event) => {
+    event.preventDefault();
+    const lostId = 0;
+
+    try {
+      const config = {
+        headers: {
+          'Content-Type': 'application/json',
+          Auth: window.localStorage.getItem('token'),
+        },
+      };
+
+      await axios.post(
+        'https://mungtage.shop/api/v1/lost/delete',
+        lostId,
+        config,
+      );
+      alert('분실 삭제가 성공적으로 완료되었습니다.');
+    } catch (error) {
+      alert('분실 삭제에 문제가 생겼습니다: ', error);
+    }
+  };
+
+  return (
+    <div className="flex justify-center h-full w-full">
+      <form className="flex h-full flex-col">
+        <div className="h-full w-full space-y-10">
+          <div className="flex flex-col mb-2">
+            <div className="flex relative">
+              <span className="w-1/3 rounded-l-md inline-flex  items-center px-5 bg-white border-black text-black shadow-sm text-sm">
+                반려 동물 이름
+              </span>
+              <input
+                name="animalName"
+                value={formData.animalName || ''}
+                type="string"
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                disabled
+              />
+            </div>
+          </div>
+          <div className="flex flex-col mb-2">
+            <div className="flex relative">
+              <span className="w-1/3 rounded-l-md inline-flex  items-center px-5 bg-white border-black text-black shadow-sm text-sm">
+                실종 날짜
+              </span>
+
+              <input
+                type="lostDate"
+                name="date"
+                value={formData.happenDate || ''}
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                disabled
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col mb-2">
+            <div className="flex relative">
+              <span className="w-1/3 rounded-l-md inline-flex  items-center px-5 bg-white border-black text-black shadow-sm text-sm">
+                성별
+              </span>
+              <input
+                type="gender"
+                value={formData.sexCode || ''}
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col mb-2">
+            <div className="flex relative">
+              <span className="w-1/3 rounded-l-md inline-flex  items-center px-5 bg-white border-black text-black shadow-sm text-sm">
+                중성화
+              </span>
+              <input
+                type="neuter"
+                value={formData.neuterYN || ''}
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+              />
+            </div>
+          </div>
+
+          <div className="flex flex-col mb-2">
+            <div className="flex relative">
+              <button
+                type="submit"
+                className="text-center rounded-lg flex-1 appearance-none w-full py-3 px-20 bg-point-color text-white font-bold placeholder-black shadow-sm text-lg focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                onClick={onDelete}
+              >
+                삭제
+              </button>
+            </div>
+          </div>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+export default IsLostForm;

--- a/src/components/lostPostTab/IsLostForm.js
+++ b/src/components/lostPostTab/IsLostForm.js
@@ -40,7 +40,7 @@ function IsLostForm({ formData = [] }) {
                 name="animalName"
                 value={formData.animalName || ''}
                 type="string"
-                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-gray-100 text-gray-400 placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
                 disabled
               />
             </div>
@@ -55,7 +55,7 @@ function IsLostForm({ formData = [] }) {
                 type="lostDate"
                 name="date"
                 value={formData.happenDate || ''}
-                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-gray-100 text-gray-400 placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
                 disabled
               />
             </div>
@@ -69,7 +69,7 @@ function IsLostForm({ formData = [] }) {
               <input
                 type="gender"
                 value={formData.sexCode || ''}
-                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20  bg-gray-100 text-gray-400 placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
               />
             </div>
           </div>
@@ -82,7 +82,7 @@ function IsLostForm({ formData = [] }) {
               <input
                 type="neuter"
                 value={formData.neuterYN || ''}
-                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-white text-black placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+                className="text-center rounded-r-lg flex-1 appearance-none border-l border-gray-100 w-full py-3 px-20 bg-gray-100 text-gray-400 placeholder-black shadow-sm text-base focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
               />
             </div>
           </div>

--- a/src/components/lostPostTab/LostPost.js
+++ b/src/components/lostPostTab/LostPost.js
@@ -1,12 +1,35 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
+import axios from 'axios';
 import ImageUpload from './ImageUpload';
 import LostForm from './LostForm';
 
 function LostPost() {
   const [imageURL, setImageURL] = useState('');
+  const [lostPosts, setLostPosts] = useState([]);
   const handleImageURL = (url) => {
     setImageURL(url);
   };
+  const accessToken = window.localStorage.getItem('token');
+  const getLost = async () => {
+    try {
+      const response = await axios.get(`https://mungtage.shop/api/v1/lost`, {
+        headers: {
+          Auth: accessToken,
+        },
+      });
+      setLostPosts(response.data.pop());
+    } catch (e) {
+      alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
+    }
+  };
+
+  useEffect(() => {
+    if (accessToken) {
+      getLost();
+    } else {
+      alert('로그인이 필요합니다.');
+    }
+  }, []);
 
   return (
     <div className="mt-[50px] pb-[100px]">
@@ -15,7 +38,7 @@ function LostPost() {
           <ImageUpload onImageURL={handleImageURL} />
         </div>
         <div className="flex w-[50%] pl-[20px]">
-          <LostForm imageURL={imageURL} />
+          <LostForm imageURL={imageURL} formData={lostPosts} />
         </div>
       </div>
     </div>

--- a/src/components/lostPostTab/LostPost.js
+++ b/src/components/lostPostTab/LostPost.js
@@ -17,7 +17,9 @@ function LostPost() {
           Auth: accessToken,
         },
       });
-      setLostPosts(response.data.pop());
+      if (response.data) {
+        setLostPosts(response.data);
+      }
     } catch (e) {
       alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
     }

--- a/src/components/lostPostTab/LostPost.js
+++ b/src/components/lostPostTab/LostPost.js
@@ -1,11 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import axios from 'axios';
 import ImageUpload from './ImageUpload';
+import IsImageUpload from './IsImageUpload';
 import LostForm from './LostForm';
+import IsLostForm from './IsLostForm';
 
 function LostPost() {
   const [imageURL, setImageURL] = useState('');
-  const [lostPosts, setLostPosts] = useState([]);
+  const [lostPost, setLostPost] = useState();
+  const [isPost, setIsPost] = useState();
+
   const handleImageURL = (url) => {
     setImageURL(url);
   };
@@ -17,8 +21,11 @@ function LostPost() {
           Auth: accessToken,
         },
       });
-      if (response.data) {
-        setLostPosts(response.data);
+      if (response.data.length) {
+        setIsPost(true);
+        setLostPost(response.data.pop());
+      } else {
+        setIsPost(false);
       }
     } catch (e) {
       alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
@@ -37,10 +44,18 @@ function LostPost() {
     <div className="mt-[50px] pb-[100px]">
       <div className="flex h-[100%] div-folder">
         <div className="flex w-[50%] pr-[20px]">
-          <ImageUpload onImageURL={handleImageURL} />
+          {isPost ? (
+            <IsImageUpload imageURL={lostPost.image} />
+          ) : (
+            <ImageUpload onImageURL={handleImageURL} />
+          )}
         </div>
         <div className="flex w-[50%] pl-[20px]">
-          <LostForm imageURL={imageURL} formData={lostPosts} />
+          {isPost ? (
+            <IsLostForm formData={lostPost} />
+          ) : (
+            <LostForm imageURL={imageURL} />
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
- 분실 등록 내역이 있는 경우
<img width="915" alt="image" src="https://user-images.githubusercontent.com/20448972/198702179-e41bb179-12a1-470a-baf1-8b17ecbaf431.png">

- 분실 등록 내역이 없는 경우  
<img width="926" alt="image" src="https://user-images.githubusercontent.com/20448972/198703166-0600347b-3bca-454c-a679-9a0e82da2e63.png">

- 분실 등록 내역이 있는 경우 기존 내역(여러개라면 최근 1개)을 표시
- input 부분 회색 음영 처리
- input  입력 불가능하게 수정
- 삭제 버튼 

api 나 기존 컴포넌트 재활용하고 싶었는데 머리가 굳어서 그냥 컴포넌트 따로 각각 만들었어요.

todo 
- 입력 부분을 라디오 버튼으로 수정