### PR TITLE
로그아웃 해도 등록된 실종 신고는 그대로 보이는 이슈

### DIFF
--- a/src/components/base/Header.js
+++ b/src/components/base/Header.js
@@ -46,7 +46,7 @@ function Header() {
               </a>
             ) : (
               <button type="button" onClick={logoutHandler}>
-                로그아웃
+                <a href={`${window.location.origin}`}>로그아웃</a>
               </button>
             )}
           </div>


### PR DESCRIPTION
변경 내역: 이제 로그아웃하면 글 내역이 나타나지 않습니다.
방법 : Header.js에서 로그아웃을 눌렀을 경우 a태그를 이용해 홈으로 이동하도록 변경

로그아웃시 LostForm 컴포넌트에 변화를 주어야 리렌더링이 일어나야 했습니다.
그러려면 로그아웃하는 부분인 Header.js의 accessToken state를 App.js 까지 끌어올려 LostForm까지 내려보내야 하는데 막막한 생각이 들었습니다. 

좋은 방법은 아닐지 몰라도 어차피 로그인할 때도 깜빡이도록 해놓으셨겠다 로그아웃도 깜빡임을 감수하면서 a태그로 LostForm을 새로고침하였습니다.