### PR TITLE
Feature/#53 더보기 버튼 구현

### DIFF
--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -7,7 +7,7 @@ import RenderList from './RenderList';
 function MatchResult({ result, lost }) {
   const accessToken = window.localStorage.getItem('token');
   const [pageNum, setPageNum] = useState(1);
-  const [maxPage, setMaxPage] = useState(0);
+  const maxPage = 12;
   const [results, setResults] = useState([...result]);
   const navigate = useNavigate();
 
@@ -27,7 +27,6 @@ function MatchResult({ result, lost }) {
           },
         );
         setResults([...results, ...response.data.data]);
-        setMaxPage(response.data.meta.pageCount);
       } catch (e) {
         alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
         navigate('/');

--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -54,7 +54,7 @@ function MatchResult({ lost }) {
       </div>
       {!isLoading ? (
         <>
-          <main className="w-[inherit] mx-auto my-0 text-[0px] flex flex-wrap justify-center">
+          <main className="w-[inherit] mx-auto my-0 text-[0px] inline-flex flex-wrap justify-center">
             <RenderList list={results} key={results.rank} />
           </main>
           {pageNum <= maxPage && (

--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -1,8 +1,42 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
 import PropTypes from 'prop-types';
 import RenderList from './RenderList';
 
 function MatchResult({ result, lost }) {
+  const accessToken = window.localStorage.getItem('token');
+  const [pageNum, setPageNum] = useState(1);
+  const [maxPage, setMaxPage] = useState(0);
+  const [results, setResults] = useState([...result]);
+  const navigate = useNavigate();
+
+  const loadMore = () => {
+    if (pageNum >= maxPage) {
+      alert('마지막 페이지입니다.');
+    }
+    setPageNum((prev) => prev + 1);
+    const getResult = async (id, pageNumber, loadSize) => {
+      try {
+        const response = await axios.get(
+          `https://mungtage.shop/api/v1/match?lostId=${id}&page=${pageNumber}$size=${loadSize}`,
+          {
+            headers: {
+              Auth: accessToken,
+            },
+          },
+        );
+        setResults([...results, ...response.data.data]);
+        setMaxPage(response.data.meta.pageCount);
+      } catch (e) {
+        alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
+        navigate('/');
+      }
+    };
+    useEffect(() => {
+      getResult(lost.id, pageNum, 9);
+    }, [pageNum]);
+  };
   return (
     <div className="flex flex-col items-center">
       <div className="text-lg">
@@ -12,6 +46,11 @@ function MatchResult({ result, lost }) {
       <main className="w-screen mx-auto my-0 text-[0px] flex flex-wrap">
         <RenderList list={result} key={result.desertionNo} />
       </main>
+      {pageNum <= maxPage && (
+        <button type="button" onClick={loadMore}>
+          더 보기
+        </button>
+      )}
     </div>
   );
 }

--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -8,8 +8,8 @@ import Waiting from '../base/Waiting';
 
 function MatchResult({ lost }) {
   const accessToken = window.localStorage.getItem('token');
-  const [pageNum, setPageNum] = useState(1);
-  const maxPage = 12;
+  const [pageNum, setPageNum] = useState(0);
+  const maxPage = 11;
   const [results, setResults] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
@@ -24,7 +24,7 @@ function MatchResult({ lost }) {
     try {
       setIsLoading(true);
       const response = await axios.get(
-        `https://mungtage.shop/api/v1/match?lostId=${id}&page=${pageNumber}$size=${loadSize}`,
+        `https://mungtage.shop/api/v1/match?lostId=${id}&page=${pageNumber}&size=${loadSize}`,
         {
           headers: {
             Auth: accessToken,
@@ -41,23 +41,28 @@ function MatchResult({ lost }) {
   };
   useEffect(() => {
     console.log('pageNum: ', pageNum);
-    getResult(lost.id, pageNum, 9);
+    getResult(34, pageNum, 9);
+    // getResult(lost.id, pageNum, 9);
   }, [pageNum]);
 
   console.log(results);
   return (
     <div className="flex flex-col items-center">
-      <div className="text-lg">
+      <div className="text-lg mb-8">
         <span className="font-bold">{lost.animalName}</span>(이)와 가장 닮은
         아이들입니다.
       </div>
       {!isLoading ? (
         <>
-          <main className="w-screen mx-auto my-0 text-[0px] flex flex-wrap">
+          <main className="w-[inherit] mx-auto my-0 text-[0px] flex flex-wrap justify-center">
             <RenderList list={results} key={results.rank} />
           </main>
           {pageNum <= maxPage && (
-            <button type="button" onClick={loadMore}>
+            <button
+              type="button"
+              onClick={loadMore}
+              className="text-center rounded-lg flex-1 appearance-none px-4 py-2 m-4 bg-folder-disabled-tab font-bold placeholder-black shadow-sm text-lg focus:outline-none focus:ring-1 focus:ring-[#ffa000]   focus:border-transparent"
+            >
               더 보기
             </button>
           )}

--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -1,54 +1,69 @@
+/* eslint-disable no-unused-vars */
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import PropTypes from 'prop-types';
 import RenderList from './RenderList';
+import Waiting from '../base/Waiting';
 
 function MatchResult({ lost }) {
   const accessToken = window.localStorage.getItem('token');
   const [pageNum, setPageNum] = useState(1);
   const maxPage = 12;
-  const [results, setResults] = useState();
+  const [results, setResults] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
 
   const loadMore = () => {
     if (pageNum >= maxPage) {
       alert('마지막 페이지입니다.');
-      setPageNum((prev) => prev + 1);
     }
-    const getResult = async (id, pageNumber, loadSize) => {
-      try {
-        const response = await axios.get(
-          `https://mungtage.shop/api/v1/match?lostId=${id}&page=${pageNumber}$size=${loadSize}`,
-          {
-            headers: {
-              Auth: accessToken,
-            },
-          },
-        );
-        setResults([...results, ...response.data.matchResults]);
-      } catch (e) {
-        alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
-        navigate('/');
-      }
-    };
-    useEffect(() => {
-      getResult(lost.id, pageNum, 9);
-    }, [pageNum]);
+    setPageNum((prev) => prev + 1);
   };
+  const getResult = async (id, pageNumber, loadSize) => {
+    try {
+      setIsLoading(true);
+      const response = await axios.get(
+        `https://mungtage.shop/api/v1/match?lostId=${id}&page=${pageNumber}$size=${loadSize}`,
+        {
+          headers: {
+            Auth: accessToken,
+          },
+        },
+      );
+      setResults([...results, ...response.data.matchResults]);
+    } catch (e) {
+      alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
+      navigate('/');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+  useEffect(() => {
+    console.log('pageNum: ', pageNum);
+    getResult(lost.id, pageNum, 9);
+  }, [pageNum]);
+
+  console.log(results);
   return (
     <div className="flex flex-col items-center">
       <div className="text-lg">
         <span className="font-bold">{lost.animalName}</span>(이)와 가장 닮은
         아이들입니다.
       </div>
-      <main className="w-screen mx-auto my-0 text-[0px] flex flex-wrap">
-        <RenderList list={results} key={results.rank} />
-      </main>
-      {pageNum <= maxPage && (
-        <button type="button" onClick={loadMore}>
-          더 보기
-        </button>
+      {!isLoading ? (
+        <>
+          <main className="w-screen mx-auto my-0 text-[0px] flex flex-wrap">
+            <RenderList list={results} key={results.rank} />
+          </main>
+          {pageNum <= maxPage && (
+            <button type="button" onClick={loadMore}>
+              더 보기
+            </button>
+          )}
+        </>
+      ) : (
+        <Waiting />
       )}
     </div>
   );

--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -40,12 +40,10 @@ function MatchResult({ lost }) {
     }
   };
   useEffect(() => {
-    console.log('pageNum: ', pageNum);
-    getResult(34, pageNum, 9);
-    // getResult(lost.id, pageNum, 9);
+    // getResult(34, pageNum, 9);
+    getResult(lost.id, pageNum, 9);
   }, [pageNum]);
 
-  console.log(results);
   return (
     <div className="flex flex-col items-center">
       <div className="text-lg mb-8">

--- a/src/components/resultTab/MatchResult.js
+++ b/src/components/resultTab/MatchResult.js
@@ -4,18 +4,18 @@ import axios from 'axios';
 import PropTypes from 'prop-types';
 import RenderList from './RenderList';
 
-function MatchResult({ result, lost }) {
+function MatchResult({ lost }) {
   const accessToken = window.localStorage.getItem('token');
   const [pageNum, setPageNum] = useState(1);
   const maxPage = 12;
-  const [results, setResults] = useState([...result]);
+  const [results, setResults] = useState();
   const navigate = useNavigate();
 
   const loadMore = () => {
     if (pageNum >= maxPage) {
       alert('마지막 페이지입니다.');
+      setPageNum((prev) => prev + 1);
     }
-    setPageNum((prev) => prev + 1);
     const getResult = async (id, pageNumber, loadSize) => {
       try {
         const response = await axios.get(
@@ -26,7 +26,7 @@ function MatchResult({ result, lost }) {
             },
           },
         );
-        setResults([...results, ...response.data.data]);
+        setResults([...results, ...response.data.matchResults]);
       } catch (e) {
         alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
         navigate('/');
@@ -43,7 +43,7 @@ function MatchResult({ result, lost }) {
         아이들입니다.
       </div>
       <main className="w-screen mx-auto my-0 text-[0px] flex flex-wrap">
-        <RenderList list={result} key={result.desertionNo} />
+        <RenderList list={results} key={results.rank} />
       </main>
       {pageNum <= maxPage && (
         <button type="button" onClick={loadMore}>
@@ -55,11 +55,9 @@ function MatchResult({ result, lost }) {
 }
 
 MatchResult.defaultProps = {
-  result: null,
   lost: null,
 };
 MatchResult.propTypes = {
-  result: PropTypes.instanceOf(Array),
   lost: PropTypes.instanceOf(Object),
 };
 

--- a/src/components/resultTab/RenderList.js
+++ b/src/components/resultTab/RenderList.js
@@ -29,5 +29,11 @@ export default function RenderList({ list }) {
       </article>
     );
   });
+  lists.push(
+    <span
+      key="dumbSpan"
+      className="inline-block overflow-hidden h-90 cursor-pointer m-3 w-[300px]"
+    />,
+  );
   return lists;
 }

--- a/src/components/resultTab/RenderList.js
+++ b/src/components/resultTab/RenderList.js
@@ -3,12 +3,11 @@ import { Link } from 'react-router-dom';
 
 export default function RenderList({ list }) {
   const lists = list.map((rescue) => {
-    const { happenDt, imageUrl, desertionNo } = rescue;
-
+    const { happenDt, imageUrl, desertionNo, rank } = rescue;
     return (
       <article
-        key={desertionNo}
-        className="inline-block shadow-lg rounded-lg overflow-hidden h-90 cursor-pointer m-3"
+        key={rank}
+        className="inline-block shadow-lg rounded-lg overflow-hidden h-90 cursor-pointer m-3 w-[300px]"
       >
         <Link
           to={`/rescue/${desertionNo}`}

--- a/src/components/resultTab/ResultTab.js
+++ b/src/components/resultTab/ResultTab.js
@@ -13,10 +13,10 @@ function ResultTab() {
   const accessToken = window.localStorage.getItem('token');
   const navigate = useNavigate();
 
-  const getResult = async (id) => {
+  const getResult = async (id, pageNum, loadSize) => {
     try {
       const response = await axios.get(
-        `https://mungtage.shop/api/v1/match?lostId=${id}`,
+        `https://mungtage.shop/api/v1/match?lostId=${id}&page=${pageNum}&size=${loadSize}`,
         {
           headers: {
             Auth: accessToken,
@@ -49,7 +49,7 @@ function ResultTab() {
         setLost(response.data[0]);
         window.localStorage.setItem('animalName', response.data[0].animalName);
         window.localStorage.setItem('image', response.data[0].image);
-        getResult(response.data[0].id);
+        getResult(response.data[0].id, 1, 9);
       }
     } catch (e) {
       alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);

--- a/src/components/resultTab/ResultTab.js
+++ b/src/components/resultTab/ResultTab.js
@@ -22,7 +22,7 @@ function ResultTab() {
           },
         },
       );
-      if (response.data.length === 0) {
+      if (response.data.matchResults.length === 0) {
         setMatchState('noResult');
       } else {
         setMatchState('matchResult');

--- a/src/components/resultTab/ResultTab.js
+++ b/src/components/resultTab/ResultTab.js
@@ -8,7 +8,6 @@ import Waiting from '../base/Waiting';
 
 function ResultTab() {
   const [matchState, setMatchState] = useState('waiting');
-  const [matchResult, setMatchResult] = useState();
   const [lost, setLost] = useState();
   const accessToken = window.localStorage.getItem('token');
   const navigate = useNavigate();
@@ -27,7 +26,6 @@ function ResultTab() {
         setMatchState('noResult');
       } else {
         setMatchState('matchResult');
-        setMatchResult(response.data.matchResults);
       }
     } catch (e) {
       alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);
@@ -68,7 +66,7 @@ function ResultTab() {
 
   function resultContent(state) {
     if (state === 'matchResult') {
-      return <MatchResult result={matchResult} lost={lost} />;
+      return <MatchResult lost={lost} />;
     }
     if (state === 'noResult') {
       return <NoResult />;

--- a/src/components/resultTab/ResultTab.js
+++ b/src/components/resultTab/ResultTab.js
@@ -47,8 +47,8 @@ function ResultTab() {
         setLost(response.data[0]);
         window.localStorage.setItem('animalName', response.data[0].animalName);
         window.localStorage.setItem('image', response.data[0].image);
-        // getResult(response.data[0].id, 0, 9);
-        getResult(34, 0, 9);
+        getResult(response.data[0].id, 0, 9);
+        // getResult(34, 0, 9);
       }
     } catch (e) {
       alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);

--- a/src/components/resultTab/ResultTab.js
+++ b/src/components/resultTab/ResultTab.js
@@ -47,7 +47,8 @@ function ResultTab() {
         setLost(response.data[0]);
         window.localStorage.setItem('animalName', response.data[0].animalName);
         window.localStorage.setItem('image', response.data[0].image);
-        getResult(response.data[0].id, 1, 9);
+        // getResult(response.data[0].id, 0, 9);
+        getResult(34, 0, 9);
       }
     } catch (e) {
       alert(`통신 오류가 발생했습니다. 다시 시도해주세요: ${e}`);


### PR DESCRIPTION
실종 등록 탭에서 이미 등록된 게 있는지 조회하기 때문에 결과탭에서 신고조회 api도 뺄 수 있을 것 같고
`<ResultTab>`과 `<MatchResult>`의 중복되는 `getResult` 함수도 하나로 통합할 수 있을 것 같은데
지금 하기에는 너무 대대적인 리팩토링이 필요해서 뭐 잘못될까봐 그냥 뒀습니다...

더불어, 현재는 더보기 버튼 누를 때마다 스크롤이 상단으로 이동합니다. 저번이랑 똑같이 구현했는데 왜 이러는지 모르겠지만 일단 머지하고 고쳐보겠습니다.