### PR TITLE
Bugfix/#67 분실 삭제 이후 분실 등록으로 이동하지 않는 이슈

### DIFF
--- a/src/components/lostPostTab/IsLostForm.js
+++ b/src/components/lostPostTab/IsLostForm.js
@@ -3,7 +3,7 @@ import React from 'react';
 import axios from 'axios';
 import Alert from '../base/Alert';
 
-function IsLostForm({ formData = [] }) {
+function IsLostForm({ formData = [], setLostPost }) {
   const genderAnswerObj = {
     M: '수컷',
     F: '암컷',
@@ -28,6 +28,7 @@ function IsLostForm({ formData = [] }) {
 
       await axios.delete(`https://mungtage.shop/api/v1/lost/${lostId}`, config);
       Alert('success', '분실 삭제가 성공적으로 완료되었습니다.');
+      setLostPost();
     } catch (error) {
       Alert('fail', `분실 삭제에 문제가 생겼습니다: ${error}`);
     }

--- a/src/components/lostPostTab/LostPost.js
+++ b/src/components/lostPostTab/LostPost.js
@@ -9,7 +9,6 @@ import Alert from '../base/Alert';
 function LostPost() {
   const [imageURL, setImageURL] = useState('');
   const [lostPost, setLostPost] = useState();
-  const [isPost, setIsPost] = useState();
 
   const handleImageURL = (url) => {
     setImageURL(url);
@@ -23,10 +22,7 @@ function LostPost() {
         },
       });
       if (response.data.length) {
-        setIsPost(true);
         setLostPost(response.data.pop());
-      } else {
-        setIsPost(false);
       }
     } catch (error) {
       Alert('fail', `통신 오류가 발생했습니다. 다시 시도해주세요: ${error}`);
@@ -37,21 +33,21 @@ function LostPost() {
     if (accessToken) {
       getLost();
     }
-  }, []);
+  }, [lostPost]);
 
   return (
     <div className="pb-[100px]">
       <div className="flex h-[100%] div-folder">
         <div className="flex w-[50%] pr-[20px]">
-          {isPost ? (
+          {lostPost ? (
             <IsImageUpload imageURL={lostPost.image} />
           ) : (
             <ImageUpload onImageURL={handleImageURL} />
           )}
         </div>
         <div className="flex w-[50%] pl-[20px]">
-          {isPost ? (
-            <IsLostForm formData={lostPost} />
+          {lostPost ? (
+            <IsLostForm formData={lostPost} setLostPost={setLostPost} />
           ) : (
             <LostForm imageURL={imageURL} />
           )}


### PR DESCRIPTION
- 현상 : 분실 삭제시 분실 등록 컴포넌트로 이동하지 않는 이슈가 있었습니다.
- 해결 : 분실 내역 state에 따라 컴포넌트가 다르게 보이도록 하였습니다.
LostPost가 undefined 상태일 경우 등록 컴포넌트가 나타나고 값이 들어 있을 경우 삭제 컴포넌트가 나타납니다. 
삭제를 한다면 LostPost를 초기화하여 등록 컴포넌트가 나타나도록 합니다.
